### PR TITLE
Include /run/media when searching for mounts

### DIFF
--- a/lib/block-dev.sh
+++ b/lib/block-dev.sh
@@ -17,6 +17,9 @@ BLOCK_DEV_get(){
 				/media/*)
 					:
 					;;
+				/run/media/*)
+					:
+					;;
 				*)
 					local blk_show=0
 					break


### PR DESCRIPTION
Some distributions of linux (such as Fedora 41) by default will mount devices to /run/media instead of /media.